### PR TITLE
feat(ui): improve avatar fallback handling on image error

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -1,3 +1,7 @@
 ## 2025-12-27 - Missing Skip-to-Content Pattern
 **Learning:** The `apps/main` layout was missing a standard "Skip to content" link, which is a critical WCAG 2.4.1 requirement. This forces keyboard users to navigate through the entire header on every page load.
 **Action:** Always verify global layouts for skip links. When adding them, ensure the target (`<main id="main-content">`) exists and wraps the page content properly.
+
+## 2026-01-27 - Resilient Avatar Fallbacks
+**Learning:** The `Avatar` component failed silently when an image source was provided but failed to load (404), rendering nothing instead of the fallback initials. This is a common pattern where "unhappy paths" for images are overlooked.
+**Action:** Always implement `onError` handling for user-provided images to gracefully degrade to fallbacks, ensuring identity is always represented.

--- a/packages/ui/components/avatar.tsx
+++ b/packages/ui/components/avatar.tsx
@@ -1,60 +1,70 @@
-import { forwardRef } from 'react';
-import { cn } from '../utils/cn';
+"use client";
+
+import { forwardRef, useState, useEffect } from "react";
+import { cn } from "../utils/cn";
 
 export interface AvatarProps extends React.HTMLAttributes<HTMLDivElement> {
   src?: string;
   alt?: string;
   fallback?: string;
-  size?: 'sm' | 'md' | 'lg' | 'xl';
+  size?: "sm" | "md" | "lg" | "xl";
 }
 
 const sizeClasses = {
-  sm: 'h-8 w-8 text-xs',
-  md: 'h-10 w-10 text-sm',
-  lg: 'h-12 w-12 text-base',
-  xl: 'h-16 w-16 text-lg',
+  sm: "h-8 w-8 text-xs",
+  md: "h-10 w-10 text-sm",
+  lg: "h-12 w-12 text-base",
+  xl: "h-16 w-16 text-lg",
 };
 
 export const Avatar = forwardRef<HTMLDivElement, AvatarProps>(
-  ({ src, alt, fallback, size = 'md', className, ...props }, ref) => {
+  ({ src, alt, fallback, size = "md", className, ...props }, ref) => {
+    const [hasError, setHasError] = useState(false);
+
+    useEffect(() => {
+      setHasError(false);
+    }, [src]);
+
     const initials = fallback
-      ? fallback
-          .split(' ')
-          .map((n) => n[0])
-          .join('')
-          .toUpperCase()
-          .slice(0, 2)
-      : '?';
+      ? fallback.length <= 2
+        ? fallback.toUpperCase()
+        : fallback
+            .split(" ")
+            .map((n) => n[0])
+            .join("")
+            .toUpperCase()
+            .slice(0, 2)
+      : "?";
 
     return (
       <div
         ref={ref}
         className={cn(
-          'relative inline-flex items-center justify-center overflow-hidden rounded-full bg-muted',
+          "relative inline-flex items-center justify-center overflow-hidden rounded-full bg-muted",
           sizeClasses[size],
-          className
+          className,
         )}
         {...props}
       >
-        {src ? (
+        {src && !hasError ? (
           <img
             src={src}
-            alt={alt || fallback || 'Avatar'}
+            alt={alt || fallback || "Avatar"}
             className="h-full w-full object-cover"
-            onError={(e) => {
-              // Hide image on error and show fallback
-              e.currentTarget.style.display = 'none';
-            }}
+            onError={() => setHasError(true)}
           />
         ) : null}
-        {!src && (
-          <span className="font-medium text-muted-foreground" aria-label={alt || fallback}>
+        {(!src || hasError) && (
+          <span
+            className="font-medium text-muted-foreground"
+            aria-label={alt || fallback}
+          >
             {initials}
           </span>
         )}
       </div>
     );
-  }
+  },
 );
 
-Avatar.displayName = 'Avatar';
+Avatar.displayName = "Avatar";


### PR DESCRIPTION
Improved the `Avatar` component to gracefully handle image loading errors. Previously, if an image URL was provided but failed to load (e.g. 404), the component would render nothing (empty circle). Now, it detects the error and renders the fallback initials instead, ensuring the user is always represented. Also improved the logic for generating initials from fallback text.

---
*PR created automatically by Jules for task [10922740131484662513](https://jules.google.com/task/10922740131484662513) started by @drgaciw*