### PR TITLE
fix(ui): show Avatar fallback when image fails to load

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -1,3 +1,7 @@
 ## 2025-12-27 - Missing Skip-to-Content Pattern
 **Learning:** The `apps/main` layout was missing a standard "Skip to content" link, which is a critical WCAG 2.4.1 requirement. This forces keyboard users to navigate through the entire header on every page load.
 **Action:** Always verify global layouts for skip links. When adding them, ensure the target (`<main id="main-content">`) exists and wraps the page content properly.
+
+## 2026-01-30 - Client-Side Image Fallbacks
+**Learning:** The `Avatar` component failed to show fallbacks for broken image URLs because it relied solely on the presence of the `src` prop, not the loading status. This pattern required converting to a Client Component to track `onError` state.
+**Action:** When implementing image components, always verify how `onError` interacts with fallback visibility. Use state to track loading failures.

--- a/packages/ui/components/avatar.tsx
+++ b/packages/ui/components/avatar.tsx
@@ -1,4 +1,6 @@
-import { forwardRef } from 'react';
+'use client';
+
+import { forwardRef, useState, useEffect } from 'react';
 import { cn } from '../utils/cn';
 
 export interface AvatarProps extends React.HTMLAttributes<HTMLDivElement> {
@@ -17,6 +19,12 @@ const sizeClasses = {
 
 export const Avatar = forwardRef<HTMLDivElement, AvatarProps>(
   ({ src, alt, fallback, size = 'md', className, ...props }, ref) => {
+    const [hasError, setHasError] = useState(false);
+
+    useEffect(() => {
+      setHasError(false);
+    }, [src]);
+
     const initials = fallback
       ? fallback
           .split(' ')
@@ -36,18 +44,15 @@ export const Avatar = forwardRef<HTMLDivElement, AvatarProps>(
         )}
         {...props}
       >
-        {src ? (
+        {src && !hasError ? (
           <img
             src={src}
             alt={alt || fallback || 'Avatar'}
             className="h-full w-full object-cover"
-            onError={(e) => {
-              // Hide image on error and show fallback
-              e.currentTarget.style.display = 'none';
-            }}
+            onError={() => setHasError(true)}
           />
         ) : null}
-        {!src && (
+        {(!src || hasError) && (
           <span className="font-medium text-muted-foreground" aria-label={alt || fallback}>
             {initials}
           </span>


### PR DESCRIPTION
This PR improves the Avatar component by adding error handling for broken image URLs. Previously, if an image URL was provided but failed to load, the component would hide the broken image icon but also fail to show the fallback initials, leaving an empty circle.

Changes:
- Converted `Avatar` to a Client Component (`'use client'`).
- Added `hasError` state to track loading failures.
- Updated rendering logic to show fallback if `!src` OR `hasError`.
- Added `useEffect` to reset error state when `src` changes.

This ensures a consistent and accessible experience even when external image resources fail.

---
*PR created automatically by Jules for task [13153463974957379372](https://jules.google.com/task/13153463974957379372) started by @drgaciw*