### PR TITLE
🎨 Palette: Enhance Textarea with error state and design tokens

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -1,3 +1,7 @@
 ## 2025-12-27 - Missing Skip-to-Content Pattern
 **Learning:** The `apps/main` layout was missing a standard "Skip to content" link, which is a critical WCAG 2.4.1 requirement. This forces keyboard users to navigate through the entire header on every page load.
 **Action:** Always verify global layouts for skip links. When adding them, ensure the target (`<main id="main-content">`) exists and wraps the page content properly.
+
+## 2025-12-28 - Inconsistent Textarea State Patterns
+**Learning:** The `Textarea` component lacked the `error` state prop and design tokens used by `Input`, leading to inconsistent validation feedback. Forms using `react-hook-form` were passing `error` props that were ignored.
+**Action:** When auditing form components, ensure all inputs (`Textarea`, `Select`, etc.) support the standard `error` prop and mapping to `aria-invalid` to ensure consistent accessibility and visual feedback.

--- a/apps/main/app/admin/evals/datasets/page.tsx
+++ b/apps/main/app/admin/evals/datasets/page.tsx
@@ -288,6 +288,7 @@ export default function DatasetsPage() {
                 <Input
                   id="name"
                   {...datasetForm.register("name")}
+                  error={!!datasetForm.formState.errors.name}
                   placeholder="e.g., NCAA Compliance Tests v2"
                 />
                 {datasetForm.formState.errors.name && (
@@ -302,6 +303,7 @@ export default function DatasetsPage() {
                 <Textarea
                   id="description"
                   {...datasetForm.register("description")}
+                  error={!!datasetForm.formState.errors.description}
                   placeholder="Describe the purpose and contents of this dataset..."
                   rows={3}
                 />
@@ -431,6 +433,7 @@ export default function DatasetsPage() {
                         <Input
                           id="tc-name"
                           {...testCaseForm.register("name")}
+                          error={!!testCaseForm.formState.errors.name}
                           placeholder="Test case name"
                         />
                         {testCaseForm.formState.errors.name && (
@@ -445,6 +448,7 @@ export default function DatasetsPage() {
                         <Input
                           id="tc-category"
                           {...testCaseForm.register("category")}
+                          error={!!testCaseForm.formState.errors.category}
                           placeholder="e.g., Initial Eligibility"
                         />
                         {testCaseForm.formState.errors.category && (
@@ -460,6 +464,7 @@ export default function DatasetsPage() {
                       <Textarea
                         id="tc-input"
                         {...testCaseForm.register("input")}
+                        error={!!testCaseForm.formState.errors.input}
                         placeholder='{"studentId": "123", "gpa": 3.5, ...}'
                         rows={4}
                         className="font-mono text-sm"
@@ -478,6 +483,7 @@ export default function DatasetsPage() {
                       <Textarea
                         id="tc-expected"
                         {...testCaseForm.register("expected")}
+                        error={!!testCaseForm.formState.errors.expected}
                         placeholder='{"eligible": true, "issues": []}'
                         rows={4}
                         className="font-mono text-sm"

--- a/packages/ui/components/textarea.tsx
+++ b/packages/ui/components/textarea.tsx
@@ -1,20 +1,26 @@
 import { forwardRef } from 'react';
 import { cn } from '../utils/cn';
 
-export interface TextareaProps extends React.TextareaHTMLAttributes<HTMLTextAreaElement> {}
+export interface TextareaProps extends React.TextareaHTMLAttributes<HTMLTextAreaElement> {
+  error?: boolean;
+}
 
 export const Textarea = forwardRef<HTMLTextAreaElement, TextareaProps>(
-  ({ className, ...props }, ref) => {
+  ({ className, error, ...props }, ref) => {
     return (
       <textarea
         className={cn(
-          'flex min-h-[80px] w-full rounded-md border border-gray-300 bg-white px-3 py-2 text-sm',
-          'ring-offset-white placeholder:text-gray-400',
-          'focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-gray-950 focus-visible:ring-offset-2',
+          'flex min-h-[80px] w-full rounded-md border bg-background px-3 py-2 text-sm',
+          'ring-offset-background placeholder:text-muted-foreground',
+          'focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2',
           'disabled:cursor-not-allowed disabled:opacity-50',
+          error
+            ? 'border-error focus-visible:ring-error'
+            : 'border-input',
           className
         )}
         ref={ref}
+        aria-invalid={error}
         {...props}
       />
     );


### PR DESCRIPTION
💡 What: Added `error` prop to `Textarea` component and updated it to use design tokens (`border-input`, `bg-background`). Updated `DatasetsPage` to pass error state to inputs.
🎯 Why: `Textarea` was inconsistent with `Input` and lacked visual/accessible feedback for validation errors.
♿ Accessibility: Added `aria-invalid` to `Textarea` when error is present.

---
*PR created automatically by Jules for task [9734178684540898953](https://jules.google.com/task/9734178684540898953) started by @drgaciw*