### PR TITLE
🎨 Palette: Use Modal for Eval Test Details

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -1,3 +1,7 @@
 ## 2025-12-27 - Missing Skip-to-Content Pattern
 **Learning:** The `apps/main` layout was missing a standard "Skip to content" link, which is a critical WCAG 2.4.1 requirement. This forces keyboard users to navigate through the entire header on every page load.
 **Action:** Always verify global layouts for skip links. When adding them, ensure the target (`<main id="main-content">`) exists and wraps the page content properly.
+
+## 2025-12-27 - Inline Details vs Modal for Complex Data
+**Learning:** Displaying complex data like diff views (via `ReactDiffViewer`) inline below a long table causes users to lose context and miss the feedback.
+**Action:** Use a `Modal` for detailed views of complex objects linked from a table row, ensuring focus is managed and context is preserved.

--- a/apps/main/app/admin/evals/[runId]/page.tsx
+++ b/apps/main/app/admin/evals/[runId]/page.tsx
@@ -22,6 +22,7 @@ import {
   TableRow,
   TableCell,
   Button,
+  Modal,
 } from "@aah/ui";
 import type { EvalReport, RunResult } from "@/lib/types/evals";
 
@@ -368,22 +369,15 @@ export default function EvalRunDetailsPage() {
         </CardContent>
       </Card>
 
-      {/* Test Case Detail Modal (simplified as full card) */}
+      {/* Test Case Detail Modal */}
       {selectedTest && (
-        <Card className="border-2 border-blue-500">
-          <CardHeader>
-            <div className="flex items-center justify-between">
-              <CardTitle>Test Case: {selectedTest.testCase.id}</CardTitle>
-              <Button
-                variant="outline"
-                size="sm"
-                onClick={() => setSelectedTest(null)}
-              >
-                Close
-              </Button>
-            </div>
-          </CardHeader>
-          <CardContent className="space-y-4">
+        <Modal
+          open={!!selectedTest}
+          onClose={() => setSelectedTest(null)}
+          title={`Test Case: ${selectedTest.testCase.id}`}
+          size="xl"
+        >
+          <div className="space-y-4">
             {/* Input */}
             <div>
               <h3 className="font-semibold mb-2">Input:</h3>
@@ -397,7 +391,11 @@ export default function EvalRunDetailsPage() {
               <h3 className="font-semibold mb-2">Expected vs Actual Output:</h3>
               <div className="border rounded-lg overflow-hidden">
                 <ReactDiffViewer
-                  oldValue={JSON.stringify(selectedTest.score.expected, null, 2)}
+                  oldValue={JSON.stringify(
+                    selectedTest.score.expected,
+                    null,
+                    2,
+                  )}
                   newValue={JSON.stringify(selectedTest.score.actual, null, 2)}
                   splitView={true}
                   leftTitle="Expected"
@@ -431,10 +429,7 @@ export default function EvalRunDetailsPage() {
               <div>
                 <p className="text-sm text-gray-600">Timestamp</p>
                 <p className="text-sm">
-                  {format(
-                    new Date(selectedTest.timestamp),
-                    "MMM d, HH:mm:ss",
-                  )}
+                  {format(new Date(selectedTest.timestamp), "MMM d, HH:mm:ss")}
                 </p>
               </div>
             </div>
@@ -448,8 +443,8 @@ export default function EvalRunDetailsPage() {
                 </AlertDescription>
               </Alert>
             )}
-          </CardContent>
-        </Card>
+          </div>
+        </Modal>
       )}
     </div>
   );


### PR DESCRIPTION
🎨 Palette Improvement: Eval Run Details

**What:**
Replaced the inline `Card` that appeared at the bottom of the page when clicking "View Details" with a `Modal` dialog.

**Why:**
- **Context:** Users viewing a long list of test results would click "View Details" and potentially not see the card appear below the fold.
- **Focus:** The Modal focuses the user's attention on the specific test case details without cluttering the main view.
- **Accessibility:** Uses the accessible `Modal` component which handles focus trapping and keyboard navigation.

**Changes:**
- Imported `Modal` from `@aah/ui`.
- Wrapped the detail view content in `Modal` instead of `Card`.
- Removed the now redundant "Close" button inside the content (Modal has its own).

**Verification:**
- `pnpm lint --filter @aah/main` passed.
- `pnpm build --filter @aah/main` passed.
- `pnpm test --filter @aah/main` passed.

---
*PR created automatically by Jules for task [14734089735002825583](https://jules.google.com/task/14734089735002825583) started by @drgaciw*