### PR TITLE
🎨 Palette: Improve Sidebar accessibility

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -5,3 +5,7 @@
 ## 2025-05-22 - Consistent Form Error States
 **Learning:** The design system tokens for form states (e.g., 'border-error') were implemented in `Input` but missing in `Textarea`, causing visual inconsistency and accessibility gaps (missing `aria-invalid`). `Textarea` was using hardcoded colors instead of semantic tokens.
 **Action:** When working on form components, always check sibling components (e.g., Input vs Textarea) to ensure feature parity (like `error` props) and design token usage consistency.
+
+## 2025-05-23 - Collapsed Navigation Accessibility
+**Learning:** Collapsed sidebars often rely on `title` attributes for tooltips, which are inaccessible to screen reader users. The `Sidebar` component used `title` but lacked `aria-label`, making navigation links "unnamed" in collapsed state.
+**Action:** Always pair `aria-label` with `title` (or custom tooltip) for icon-only buttons/links. Ensure the inner icon is marked `aria-hidden="true"` when the container has an accessible name.

--- a/packages/ui/components/sidebar.tsx
+++ b/packages/ui/components/sidebar.tsx
@@ -18,7 +18,13 @@ export interface SidebarProps {
   collapsed?: boolean;
   onCollapsedChange?: (collapsed: boolean) => void;
   currentPath?: string;
-  LinkComponent?: React.ComponentType<{ href: string; className?: string; title?: string; children: React.ReactNode }>;
+  LinkComponent?: React.ComponentType<{
+    href: string;
+    className?: string;
+    title?: string;
+    children: React.ReactNode;
+    'aria-label'?: string;
+  }>;
   className?: string;
 }
 
@@ -79,8 +85,9 @@ export function Sidebar({
                   collapsed && 'justify-center'
                 )}
                 title={collapsed ? item.label : undefined}
+                aria-label={collapsed ? item.label : undefined}
               >
-                {Icon && <Icon className="h-5 w-5 flex-shrink-0" />}
+                {Icon && <Icon className="h-5 w-5 flex-shrink-0" aria-hidden="true" />}
                 {!collapsed && (
                   <>
                     <span className="flex-1">{item.label}</span>
@@ -106,7 +113,7 @@ export function Sidebar({
                         isActive(child.href) && 'bg-accent text-accent-foreground'
                       )}
                     >
-                      {child.icon && <child.icon className="h-4 w-4" />}
+                      {child.icon && <child.icon className="h-4 w-4" aria-hidden="true" />}
                       <span>{child.label}</span>
                     </LinkComponent>
                   ))}


### PR DESCRIPTION
This PR addresses an accessibility issue where collapsed sidebar navigation links relied solely on the `title` attribute, which is not fully accessible to screen readers. 

Changes:
- Added `aria-label` to the sidebar links when in collapsed state, using the item label as the accessible name.
- Added `aria-hidden="true"` to the icons within the links to prevent them from being announced as decorative images, ensuring a cleaner experience for screen reader users.
- Updated the `LinkComponent` type definition in `SidebarProps` to explicitly allow `aria-label`, preventing TypeScript errors.
- Added a journal entry to `.Jules/palette.md` documenting this learning.

This falls under the "Palette" mission of micro-UX improvements.

---
*PR created automatically by Jules for task [9346636437775794592](https://jules.google.com/task/9346636437775794592) started by @drgaciw*