### PR TITLE
fix(ui): use appropriate aria roles for alert variants

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -5,3 +5,7 @@
 ## 2025-05-22 - Consistent Form Error States
 **Learning:** The design system tokens for form states (e.g., 'border-error') were implemented in `Input` but missing in `Textarea`, causing visual inconsistency and accessibility gaps (missing `aria-invalid`). `Textarea` was using hardcoded colors instead of semantic tokens.
 **Action:** When working on form components, always check sibling components (e.g., Input vs Textarea) to ensure feature parity (like `error` props) and design token usage consistency.
+
+## 2026-02-06 - Dynamic Aria Roles for Alerts
+**Learning:** Using `role="alert"` for all notifications interrupts screen reader users unnecessarily. Only critical errors should be assertive (`alert`). Success, info, and warning messages should be polite (`status`).
+**Action:** When implementing notification components, dynamically set the role based on severity: `role="alert"` for errors, `role="status"` for others.

--- a/packages/ui/components/alert-banner.tsx
+++ b/packages/ui/components/alert-banner.tsx
@@ -56,7 +56,7 @@ export function AlertBanner({
 
   return (
     <div
-      role="alert"
+      role={variant === 'error' ? 'alert' : 'status'}
       className={cn(alertBannerVariants({ variant }), className)}
       {...props}
     >

--- a/packages/ui/components/alert.tsx
+++ b/packages/ui/components/alert.tsx
@@ -20,7 +20,7 @@ export const Alert = forwardRef<HTMLDivElement, AlertProps>(
     return (
       <div
         ref={ref}
-        role="alert"
+        role={variant === 'error' ? 'alert' : 'status'}
         className={cn(
           'relative w-full rounded-lg border p-4',
           variantStyles[variant],


### PR DESCRIPTION
This change improves accessibility by dynamically assigning the `role` attribute in `Alert` and `AlertBanner` components.
- `variant="error"` uses `role="alert"` (assertive).
- Other variants (`default`, `success`, `warning`, `info`) use `role="status"` (polite).

This prevents screen readers from aggressively interrupting users for non-critical notifications.
Also updated `.Jules/palette.md` with the learning.

---
*PR created automatically by Jules for task [13399258867536156401](https://jules.google.com/task/13399258867536156401) started by @drgaciw*