### PR TITLE
🎨 Palette: Add accessible labels to collapsed sidebar

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -5,3 +5,7 @@
 ## 2025-05-22 - Consistent Form Error States
 **Learning:** The design system tokens for form states (e.g., 'border-error') were implemented in `Input` but missing in `Textarea`, causing visual inconsistency and accessibility gaps (missing `aria-invalid`). `Textarea` was using hardcoded colors instead of semantic tokens.
 **Action:** When working on form components, always check sibling components (e.g., Input vs Textarea) to ensure feature parity (like `error` props) and design token usage consistency.
+
+## 2025-12-28 - Accessible Collapsed Sidebar
+**Learning:** Collapsed navigation sidebars often render icon-only links. Without explicit `aria-label` attributes, these links become inaccessible to screen reader users as the visual text label is removed.
+**Action:** When implementing collapsible sidebars, ensure the link component receives an `aria-label` (typically the item label) when collapsed, and mark the accompanying icon as `aria-hidden="true"` to prevent redundant announcements.

--- a/packages/ui/components/sidebar.tsx
+++ b/packages/ui/components/sidebar.tsx
@@ -18,7 +18,13 @@ export interface SidebarProps {
   collapsed?: boolean;
   onCollapsedChange?: (collapsed: boolean) => void;
   currentPath?: string;
-  LinkComponent?: React.ComponentType<{ href: string; className?: string; title?: string; children: React.ReactNode }>;
+  LinkComponent?: React.ComponentType<{
+    href: string;
+    className?: string;
+    title?: string;
+    'aria-label'?: string;
+    children: React.ReactNode;
+  }>;
   className?: string;
 }
 
@@ -79,8 +85,11 @@ export function Sidebar({
                   collapsed && 'justify-center'
                 )}
                 title={collapsed ? item.label : undefined}
+                aria-label={collapsed ? item.label : undefined}
               >
-                {Icon && <Icon className="h-5 w-5 flex-shrink-0" />}
+                {Icon && (
+                  <Icon className="h-5 w-5 flex-shrink-0" aria-hidden="true" />
+                )}
                 {!collapsed && (
                   <>
                     <span className="flex-1">{item.label}</span>
@@ -91,7 +100,7 @@ export function Sidebar({
                     )}
                   </>
                 )}
-                    </LinkComponent>
+              </LinkComponent>
 
               {/* Nested Items */}
               {!collapsed && item.children && (
@@ -103,10 +112,13 @@ export function Sidebar({
                       className={cn(
                         'flex items-center gap-2 rounded-lg px-3 py-1.5 text-sm transition-colors',
                         'hover:bg-accent hover:text-accent-foreground',
-                        isActive(child.href) && 'bg-accent text-accent-foreground'
+                        isActive(child.href) &&
+                          'bg-accent text-accent-foreground'
                       )}
                     >
-                      {child.icon && <child.icon className="h-4 w-4" />}
+                      {child.icon && (
+                        <child.icon className="h-4 w-4" aria-hidden="true" />
+                      )}
                       <span>{child.label}</span>
                     </LinkComponent>
                   ))}


### PR DESCRIPTION
💡 What: Updated `Sidebar` component to pass `aria-label` to links when collapsed and hide icons from screen readers.
🎯 Why: Collapsed sidebar items were inaccessible to screen reader users as the text label was hidden and no accessible name was provided.
📸 Before/After: No visual change.
♿ Accessibility: Added `aria-label` to collapsed links and `aria-hidden='true'` to decorative icons.

---
*PR created automatically by Jules for task [818395582600288189](https://jules.google.com/task/818395582600288189) started by @drgaciw*